### PR TITLE
cleanup of some failure related items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ performance analysis.
   use up computer resources in the amounts specified.
 * A configurable load factor for actual CPU load.
 * Automated provisioning of the task executor binary.
+* Configurable task failure rate.
   No manual installation steps on any slave nodes necessary.
 
 ## Planned Features

--- a/src/main/scala/io/mesosphere/mesosaurus/TaskGenerator.scala
+++ b/src/main/scala/io/mesosphere/mesosaurus/TaskGenerator.scala
@@ -16,7 +16,7 @@ class TaskGenerator(requestedTasks: Int,
         memMean: Long,
         memSigma: Long,
         offerAttempts: Int = 100,
-        percentFail: Double = 0.0) extends Logging {
+        failRate: Double = 0.0) extends Logging {
 
     private var _createdTasks = 0
     private var _forfeitedTasks = 0
@@ -91,12 +91,12 @@ class TaskGenerator(requestedTasks: Int,
             .build()
     }
 
-    private class TaskDescriptor(val arrivalTime: Int, val duration: Int, val resources: Resources, val percentFail: Double) extends Logging {
+    private class TaskDescriptor(val arrivalTime: Int, val duration: Int, val resources: Resources, val failRate: Double) extends Logging {
         var offerAttempts = 0
 
         def commandArguments(): String = {
             val cores = math.ceil(resources.cpus).toInt
-            return duration + " " + cores + " " + load + " " + resources.mem + " " + percentFail
+            return duration + " " + cores + " " + load + " " + resources.mem + " " + failRate
         }
 
         def print(): Unit = {
@@ -104,7 +104,7 @@ class TaskGenerator(requestedTasks: Int,
                 ", duration: " + duration +
                 ", cpus : " + resources.cpus +
                 ", mem: " + resources.mem +
-                ", percentFail" + percentFail)
+                ", failure fail" + failRate)
         }
     }
 
@@ -123,7 +123,7 @@ class TaskGenerator(requestedTasks: Int,
             val cpus = cpusRandom.next()
             val mem = memRandom.next().toLong
             val resources = new Resources(cpus, mem)
-            val taskDescriptor = new TaskDescriptor(arrivalTime, duration, resources, percentFail)
+            val taskDescriptor = new TaskDescriptor(arrivalTime, duration, resources, failRate)
             _taskDescriptors.add(taskDescriptor)
         }
     }

--- a/task/mesosaurus-task.cpp
+++ b/task/mesosaurus-task.cpp
@@ -17,7 +17,7 @@ const int work_loop = 100000;
 void usage(char **argv) {
   fprintf(stderr,
     "Usage: %s <duration (ms)> <number of cores> <average load (0.0 - 1.0)>"
-    " <average memory (megabytes)>\n", argv[0]);
+    " <average memory (megabytes)> <failure rate (decimal 0-1)\n", argv[0]);
   exit (EXIT_FAILURE);
 }
 
@@ -116,7 +116,7 @@ void* workerEntry(void* payload) {
 }
 
 int main(int argc, char** argv) {
-  if (argc < 5) {
+  if (argc < 6) {
     usage(argv);
   }
 


### PR DESCRIPTION
Correctly checks for arg length in mesosaurus-task.cpp and prints current usage including failure rate.
Renamed percent(age)Fail to failRate in mesosaurus.scala and TaskGenerator.scala to be more consistent with how it is actually input.
Added a better description for failure rate under mesosaurus usage.
Added listing for failure rate under current features in the README.